### PR TITLE
Feat/#1 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### Config ###
 application-prod-db.yml
+application-prod-secret.yml

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.mindrot:jbcrypt:0.4'
     implementation 'org.postgresql:postgresql'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.testcontainers:testcontainers'

--- a/src/main/java/kr/co/shop/makao/component/AuthTokenManager.java
+++ b/src/main/java/kr/co/shop/makao/component/AuthTokenManager.java
@@ -1,9 +1,11 @@
 package kr.co.shop.makao.component;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import kr.co.shop.makao.config.AuthProperties;
 import kr.co.shop.makao.enums.TokenType;
+import kr.co.shop.makao.response.CommonException;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
@@ -35,12 +37,18 @@ public class AuthTokenManager {
     }
 
     public String getSubject(String token, TokenType tokenType) {
-        var key = tokenType == TokenType.ACCESS_TOKEN ? accessTokenKey : refreshTokenKey;
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .getSubject();
+        try {
+            var key = tokenType == TokenType.ACCESS_TOKEN ? accessTokenKey : refreshTokenKey;
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        } catch (ExpiredJwtException cause) {
+            throw CommonException.BAD_REQUEST.toException("EXPIRED_REFRESH_TOKEN", cause);
+        } catch (Exception cause) {
+            throw CommonException.BAD_REQUEST.toException("INVALID_REFRESH_TOKEN", cause);
+        }
     }
 }

--- a/src/main/java/kr/co/shop/makao/component/AuthTokenManager.java
+++ b/src/main/java/kr/co/shop/makao/component/AuthTokenManager.java
@@ -1,0 +1,46 @@
+package kr.co.shop.makao.component;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import kr.co.shop.makao.config.AuthProperties;
+import kr.co.shop.makao.enums.TokenType;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class AuthTokenManager {
+    private final AuthProperties authProperties;
+    private final Key accessTokenKey;
+    private final Key refreshTokenKey;
+    private final JwtAlgorithmProvider jwtAlgorithmProvider;
+
+    public AuthTokenManager(AuthProperties authProperties, JwtAlgorithmProvider jwtAlgorithmProvider) {
+        this.authProperties = authProperties;
+        this.jwtAlgorithmProvider = jwtAlgorithmProvider;
+        this.accessTokenKey = Keys.hmacShaKeyFor(authProperties.getAccessTokenSecret().getBytes(StandardCharsets.UTF_8));
+        this.refreshTokenKey = Keys.hmacShaKeyFor(authProperties.getRefreshTokenSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String create(String subject, TokenType tokenType) {
+        var key = tokenType == TokenType.ACCESS_TOKEN ? accessTokenKey : refreshTokenKey;
+        var expiration = tokenType == TokenType.ACCESS_TOKEN ? authProperties.getAccessTokenExpiration() : authProperties.getRefreshTokenExpiration();
+        return Jwts.builder()
+                .setSubject(subject)
+                .signWith(key, jwtAlgorithmProvider.provide())
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .compact();
+    }
+
+    public String getSubject(String token, TokenType tokenType) {
+        var key = tokenType == TokenType.ACCESS_TOKEN ? accessTokenKey : refreshTokenKey;
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/src/main/java/kr/co/shop/makao/component/JwtAlgorithmProvider.java
+++ b/src/main/java/kr/co/shop/makao/component/JwtAlgorithmProvider.java
@@ -1,0 +1,7 @@
+package kr.co.shop.makao.component;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+
+public interface JwtAlgorithmProvider {
+    SignatureAlgorithm provide();
+}

--- a/src/main/java/kr/co/shop/makao/component/JwtAlgorithmProviderImpl.java
+++ b/src/main/java/kr/co/shop/makao/component/JwtAlgorithmProviderImpl.java
@@ -1,0 +1,10 @@
+package kr.co.shop.makao.component;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+
+public class JwtAlgorithmProviderImpl implements JwtAlgorithmProvider {
+    @Override
+    public SignatureAlgorithm provide() {
+        return SignatureAlgorithm.HS256;
+    }
+}

--- a/src/main/java/kr/co/shop/makao/config/AuthConfig.java
+++ b/src/main/java/kr/co/shop/makao/config/AuthConfig.java
@@ -3,6 +3,8 @@ package kr.co.shop.makao.config;
 import kr.co.shop.makao.component.AuthTokenManager;
 import kr.co.shop.makao.component.JwtAlgorithmProvider;
 import kr.co.shop.makao.component.JwtAlgorithmProviderImpl;
+import kr.co.shop.makao.filter.AuthFilter;
+import kr.co.shop.makao.filter.NoOpAuthFilter;
 import kr.co.shop.makao.filter.TokenAuthFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -11,9 +13,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class AuthConfig {
     @Bean
-    public FilterRegistrationBean<TokenAuthFilter> jwtAuthFilter(AuthTokenManager authTokenManager) {
-        FilterRegistrationBean<TokenAuthFilter> registrationBean = new FilterRegistrationBean<>();
-        registrationBean.setFilter(new TokenAuthFilter(authTokenManager));
+    public FilterRegistrationBean<AuthFilter> jwtAuthFilter(AuthTokenManager authTokenManager, AuthProperties authProperties) {
+        AuthFilter authFilter = authProperties.isDevEnv() ? new NoOpAuthFilter() : new TokenAuthFilter(authTokenManager);
+
+        FilterRegistrationBean<AuthFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(authFilter);
         registrationBean.addUrlPatterns("/not-working");
         registrationBean.setOrder(1);
         return registrationBean;

--- a/src/main/java/kr/co/shop/makao/config/AuthConfig.java
+++ b/src/main/java/kr/co/shop/makao/config/AuthConfig.java
@@ -1,0 +1,26 @@
+package kr.co.shop.makao.config;
+
+import kr.co.shop.makao.component.AuthTokenManager;
+import kr.co.shop.makao.component.JwtAlgorithmProvider;
+import kr.co.shop.makao.component.JwtAlgorithmProviderImpl;
+import kr.co.shop.makao.filter.TokenAuthFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AuthConfig {
+    @Bean
+    public FilterRegistrationBean<TokenAuthFilter> jwtAuthFilter(AuthTokenManager authTokenManager) {
+        FilterRegistrationBean<TokenAuthFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new TokenAuthFilter(authTokenManager));
+        registrationBean.addUrlPatterns("/not-working");
+        registrationBean.setOrder(1);
+        return registrationBean;
+    }
+
+    @Bean
+    public JwtAlgorithmProvider jwtAlgorithmProvider() {
+        return new JwtAlgorithmProviderImpl();
+    }
+}

--- a/src/main/java/kr/co/shop/makao/config/AuthProperties.java
+++ b/src/main/java/kr/co/shop/makao/config/AuthProperties.java
@@ -1,0 +1,47 @@
+package kr.co.shop.makao.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Setter
+@Getter
+@Component
+@ConfigurationProperties(prefix = "auth")
+public class AuthProperties {
+    private Token accessToken;
+    private Token refreshToken;
+
+    public String getAccessTokenSecret() {
+        return accessToken.secret;
+    }
+
+    public String getRefreshTokenSecret() {
+        return refreshToken.secret;
+    }
+
+    public long getAccessTokenExpiration() {
+        return convertToSeconds(accessToken.expiration);
+    }
+
+    public long getRefreshTokenExpiration() {
+        return convertToSeconds(refreshToken.expiration);
+    }
+
+    private Long convertToSeconds(String time) {
+        return Arrays
+                .stream(time.split("\\*"))
+                .map(String::trim)
+                .mapToLong(Long::parseLong)
+                .reduce(1, (a, b) -> a * b);
+    }
+
+    @Setter
+    public static class Token {
+        private String secret;
+        private String expiration;
+    }
+}

--- a/src/main/java/kr/co/shop/makao/config/AuthProperties.java
+++ b/src/main/java/kr/co/shop/makao/config/AuthProperties.java
@@ -8,12 +8,14 @@ import org.springframework.stereotype.Component;
 import java.util.Arrays;
 
 @Setter
-@Getter
 @Component
 @ConfigurationProperties(prefix = "auth")
 public class AuthProperties {
+    @Getter
     private Token accessToken;
+    @Getter
     private Token refreshToken;
+    private String isDevEnv;
 
     public String getAccessTokenSecret() {
         return accessToken.secret;
@@ -29,6 +31,10 @@ public class AuthProperties {
 
     public long getRefreshTokenExpiration() {
         return convertToSeconds(refreshToken.expiration);
+    }
+
+    public boolean isDevEnv() {
+        return Boolean.parseBoolean(isDevEnv);
     }
 
     private Long convertToSeconds(String time) {

--- a/src/main/java/kr/co/shop/makao/controller/AuthController.java
+++ b/src/main/java/kr/co/shop/makao/controller/AuthController.java
@@ -29,4 +29,9 @@ public class AuthController {
     ResponseEntity<CommonResponse<AuthDTO.SignInResponse>> signIn(@RequestBody @Valid AuthDTO.SignInRequest dto) {
         return CommonResponse.success(authService.signIn(dto));
     }
+
+    @PostMapping("/token/reissue")
+    ResponseEntity<CommonResponse<AuthDTO.TokenReissueResponse>> reissue(@RequestBody @Valid AuthDTO.TokenReissueRequest dto) {
+        return CommonResponse.success(authService.reissue(dto));
+    }
 }

--- a/src/main/java/kr/co/shop/makao/controller/AuthController.java
+++ b/src/main/java/kr/co/shop/makao/controller/AuthController.java
@@ -20,8 +20,13 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/sign-up")
-    ResponseEntity<CommonResponse<Void>> signUp(@RequestBody @Valid AuthDTO.SignUpRequest dto) {
+    ResponseEntity<CommonResponse<Void>> createProduct(@RequestBody @Valid AuthDTO.SignUpRequest dto) {
         authService.signUp(dto);
         return CommonResponse.success(null);
+    }
+
+    @PostMapping("/sign-in")
+    ResponseEntity<CommonResponse<AuthDTO.SignInResponse>> signIn(@RequestBody @Valid AuthDTO.SignInRequest dto) {
+        return CommonResponse.success(authService.signIn(dto));
     }
 }

--- a/src/main/java/kr/co/shop/makao/dto/AuthDTO.java
+++ b/src/main/java/kr/co/shop/makao/dto/AuthDTO.java
@@ -23,4 +23,21 @@ public record AuthDTO() {
             UserRole role
     ) {
     }
+
+    @Builder
+    public record SignInRequest(
+            @Email(message = "INVALID_EMAIL")
+            String email,
+            @Password
+            String password
+    ) {
+    }
+
+    @Builder
+    public record SignInResponse(
+            String accessToken,
+            String refreshToken,
+            UserRole role
+    ) {
+    }
 }

--- a/src/main/java/kr/co/shop/makao/dto/AuthDTO.java
+++ b/src/main/java/kr/co/shop/makao/dto/AuthDTO.java
@@ -40,4 +40,15 @@ public record AuthDTO() {
             UserRole role
     ) {
     }
+
+    @Builder
+    public record TokenReissueRequest(
+            @NotBlank(message = "INVALID_REFRESH_TOKEN")
+            String refreshToken
+    ) {
+    }
+
+    @Builder
+    public record TokenReissueResponse(String accessToken, String refreshToken) {
+    }
 }

--- a/src/main/java/kr/co/shop/makao/enums/TokenType.java
+++ b/src/main/java/kr/co/shop/makao/enums/TokenType.java
@@ -1,0 +1,6 @@
+package kr.co.shop.makao.enums;
+
+public enum TokenType {
+    ACCESS_TOKEN,
+    REFRESH_TOKEN
+}

--- a/src/main/java/kr/co/shop/makao/filter/AuthFilter.java
+++ b/src/main/java/kr/co/shop/makao/filter/AuthFilter.java
@@ -1,0 +1,4 @@
+package kr.co.shop.makao.filter;
+
+public abstract class AuthFilter extends CommonOncePerRequestFilter {
+}

--- a/src/main/java/kr/co/shop/makao/filter/CommonOncePerRequestFilter.java
+++ b/src/main/java/kr/co/shop/makao/filter/CommonOncePerRequestFilter.java
@@ -1,0 +1,24 @@
+package kr.co.shop.makao.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.shop.makao.response.CommonResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public abstract class CommonOncePerRequestFilter extends OncePerRequestFilter {
+    protected final ObjectMapper objectMapper = new ObjectMapper();
+
+    protected void sendErrorResponse(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        CommonResponse<Object> errorResponse = new CommonResponse<>(message, null);
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/kr/co/shop/makao/filter/NoOpAuthFilter.java
+++ b/src/main/java/kr/co/shop/makao/filter/NoOpAuthFilter.java
@@ -1,0 +1,26 @@
+package kr.co.shop.makao.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
+
+public class NoOpAuthFilter extends AuthFilter {
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws IOException, ServletException {
+        String email = request.getHeader("Authorization");
+        if (email.isBlank()) {
+            sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "INVALID_TOKEN");
+            return;
+        }
+
+        request.setAttribute("email", email);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/kr/co/shop/makao/filter/TokenAuthFilter.java
+++ b/src/main/java/kr/co/shop/makao/filter/TokenAuthFilter.java
@@ -1,0 +1,49 @@
+package kr.co.shop.makao.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.shop.makao.component.AuthTokenManager;
+import kr.co.shop.makao.enums.TokenType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TokenAuthFilter extends CommonOncePerRequestFilter {
+    private final AuthTokenManager authTokenManager;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        String token = request.getHeader("Authorization");
+
+        if (token == null || !token.startsWith("Bearer ")) {
+            sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "INVALID_TOKEN");
+            return;
+        }
+
+        token = token.substring(7);
+
+        try {
+            String subject = authTokenManager.getSubject(token, TokenType.ACCESS_TOKEN);
+
+            if (subject.isEmpty()) {
+                sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "INVALID_TOKEN");
+                return;
+            }
+
+            request.setAttribute("email", subject);
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            log.info("Invalid token", e);
+            sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN");
+        }
+    }
+}

--- a/src/main/java/kr/co/shop/makao/filter/TokenAuthFilter.java
+++ b/src/main/java/kr/co/shop/makao/filter/TokenAuthFilter.java
@@ -1,7 +1,6 @@
 package kr.co.shop.makao.filter;
 
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.co.shop.makao.component.AuthTokenManager;
@@ -14,14 +13,14 @@ import java.io.IOException;
 
 @Slf4j
 @RequiredArgsConstructor
-public class TokenAuthFilter extends CommonOncePerRequestFilter {
+public class TokenAuthFilter extends AuthFilter {
     private final AuthTokenManager authTokenManager;
 
     @Override
     protected void doFilterInternal(
             HttpServletRequest request,
             HttpServletResponse response,
-            FilterChain filterChain) throws ServletException, IOException {
+            FilterChain filterChain) throws IOException {
         String token = request.getHeader("Authorization");
 
         if (token == null || !token.startsWith("Bearer ")) {

--- a/src/main/java/kr/co/shop/makao/repository/UserRepository.java
+++ b/src/main/java/kr/co/shop/makao/repository/UserRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
     @Query("""
@@ -14,5 +16,7 @@ public interface UserRepository extends JpaRepository<User, Integer> {
             CASE WHEN EXISTS (SELECT 1 FROM user u WHERE u.phoneNumber = :phoneNumber) THEN true ELSE false END AS phoneNumberExists
             """)
     ExistsEmailAndPhoneNumber existsEmailAndPhoneNumber(@Param("email") String email, @Param("phoneNumber") String phoneNumber);
+
+    Optional<User> findByEmail(String email);
 }
 

--- a/src/main/java/kr/co/shop/makao/response/CommonException.java
+++ b/src/main/java/kr/co/shop/makao/response/CommonException.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum CommonException {
     BAD_REQUEST(HttpStatus.BAD_REQUEST),
-    IMAGE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR);
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED),
+    IMAGE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR),
+    AUTH_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final HttpStatus status;
 

--- a/src/main/java/kr/co/shop/makao/service/AuthService.java
+++ b/src/main/java/kr/co/shop/makao/service/AuthService.java
@@ -1,7 +1,5 @@
 package kr.co.shop.makao.service;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.security.SignatureException;
 import kr.co.shop.makao.component.AuthTokenManager;
 import kr.co.shop.makao.dto.AuthDTO;
 import kr.co.shop.makao.entity.User;
@@ -41,17 +39,13 @@ public class AuthService {
     }
 
     public AuthDTO.TokenReissueResponse reissue(AuthDTO.TokenReissueRequest dto) {
-        try {
-            String email = authTokenManager.getSubject(dto.refreshToken(), TokenType.REFRESH_TOKEN);
-            String accessToken = authTokenManager.create(email, TokenType.ACCESS_TOKEN);
+        String email = authTokenManager.getSubject(dto.refreshToken(), TokenType.REFRESH_TOKEN);
+        String accessToken = authTokenManager.create(email, TokenType.ACCESS_TOKEN);
+        String refreshToken = authTokenManager.create(email, TokenType.REFRESH_TOKEN);
 
-            return AuthDTO.TokenReissueResponse.builder()
-                    .accessToken(accessToken)
-                    .build();
-        } catch (ExpiredJwtException cause) {
-            throw CommonException.BAD_REQUEST.toException("EXPIRED_REFRESH_TOKEN", cause);
-        } catch (SignatureException cause) {
-            throw CommonException.BAD_REQUEST.toException("INVALID_REFRESH_TOKEN", cause);
-        }
+        return AuthDTO.TokenReissueResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
 }

--- a/src/main/java/kr/co/shop/makao/service/AuthService.java
+++ b/src/main/java/kr/co/shop/makao/service/AuthService.java
@@ -1,15 +1,52 @@
 package kr.co.shop.makao.service;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import kr.co.shop.makao.component.AuthTokenManager;
 import kr.co.shop.makao.dto.AuthDTO;
+import kr.co.shop.makao.enums.TokenType;
+import kr.co.shop.makao.response.CommonException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class AuthService {
     private final UserService userService;
+    private final AuthTokenManager authTokenManager;
 
+    @Transactional
     public void signUp(AuthDTO.SignUpRequest dto) {
         userService.save(dto);
+    }
+
+    @Transactional(readOnly = true)
+    public AuthDTO.SignInResponse signIn(AuthDTO.SignInRequest dto) {
+        if (!userService.verifyUser(dto.email(), dto.password()))
+            throw CommonException.BAD_REQUEST.toException("AUTHENTICATION_FAILED");
+
+        String accessToken = authTokenManager.create(dto.email(), TokenType.ACCESS_TOKEN);
+        String refreshToken = authTokenManager.create(dto.email(), TokenType.REFRESH_TOKEN);
+
+        return AuthDTO.SignInResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public AuthDTO.TokenReissueResponse reissue(AuthDTO.TokenReissueRequest dto) {
+        try {
+            String email = authTokenManager.getSubject(dto.refreshToken(), TokenType.REFRESH_TOKEN);
+            String accessToken = authTokenManager.create(email, TokenType.ACCESS_TOKEN);
+
+            return AuthDTO.TokenReissueResponse.builder()
+                    .accessToken(accessToken)
+                    .build();
+        } catch (ExpiredJwtException cause) {
+            throw CommonException.BAD_REQUEST.toException("EXPIRED_REFRESH_TOKEN", cause);
+        } catch (SignatureException cause) {
+            throw CommonException.BAD_REQUEST.toException("INVALID_REFRESH_TOKEN", cause);
+        }
     }
 }

--- a/src/main/java/kr/co/shop/makao/service/AuthService.java
+++ b/src/main/java/kr/co/shop/makao/service/AuthService.java
@@ -4,8 +4,10 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import kr.co.shop.makao.component.AuthTokenManager;
 import kr.co.shop.makao.dto.AuthDTO;
+import kr.co.shop.makao.entity.User;
 import kr.co.shop.makao.enums.TokenType;
 import kr.co.shop.makao.response.CommonException;
+import kr.co.shop.makao.util.StringEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +25,9 @@ public class AuthService {
 
     @Transactional(readOnly = true)
     public AuthDTO.SignInResponse signIn(AuthDTO.SignInRequest dto) {
-        if (!userService.verifyUser(dto.email(), dto.password()))
+        User user = userService.findByEmail(dto.email());
+
+        if (!StringEncoder.match(dto.password(), user.getPassword()))
             throw CommonException.BAD_REQUEST.toException("AUTHENTICATION_FAILED");
 
         String accessToken = authTokenManager.create(dto.email(), TokenType.ACCESS_TOKEN);
@@ -32,6 +36,7 @@ public class AuthService {
         return AuthDTO.SignInResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .role(user.getRole())
                 .build();
     }
 

--- a/src/main/java/kr/co/shop/makao/service/UserService.java
+++ b/src/main/java/kr/co/shop/makao/service/UserService.java
@@ -1,6 +1,5 @@
 package kr.co.shop.makao.service;
 
-import jakarta.transaction.Transactional;
 import kr.co.shop.makao.dto.AuthDTO;
 import kr.co.shop.makao.entity.User;
 import kr.co.shop.makao.repository.UserRepository;
@@ -8,6 +7,7 @@ import kr.co.shop.makao.response.CommonException;
 import kr.co.shop.makao.util.StringEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -31,5 +31,13 @@ public class UserService {
                 .build();
 
         userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean verifyUser(String email, String password) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> CommonException.BAD_REQUEST.toException("USER_NOT_FOUND"));
+
+        return StringEncoder.match(password, user.getPassword());
     }
 }

--- a/src/main/java/kr/co/shop/makao/service/UserService.java
+++ b/src/main/java/kr/co/shop/makao/service/UserService.java
@@ -34,10 +34,8 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public boolean verifyUser(String email, String password) {
-        User user = userRepository.findByEmail(email)
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email)
                 .orElseThrow(() -> CommonException.BAD_REQUEST.toException("USER_NOT_FOUND"));
-
-        return StringEncoder.match(password, user.getPassword());
     }
 }

--- a/src/main/java/kr/co/shop/makao/util/RandomString.java
+++ b/src/main/java/kr/co/shop/makao/util/RandomString.java
@@ -1,0 +1,14 @@
+package kr.co.shop.makao.util;
+
+public class RandomString {
+    private static final String ENG_DIGIT_STRING = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    public static String generateEngDigit(int length) {
+        StringBuilder builder = new StringBuilder();
+        while (length-- != 0) {
+            int character = (int) (Math.random() * ENG_DIGIT_STRING.length());
+            builder.append(ENG_DIGIT_STRING.charAt(character));
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/resources/application-local-secret.yml
+++ b/src/main/resources/application-local-secret.yml
@@ -5,3 +5,4 @@ auth:
   refresh-token:
     secret: tesaevdv123edsftesaevdv123edsftesaevdv112
     expiration: 1000 * 60 * 60 * 3 # 3 hours
+  is-dev-env: true

--- a/src/main/resources/application-local-secret.yml
+++ b/src/main/resources/application-local-secret.yml
@@ -1,0 +1,7 @@
+auth:
+  access-token:
+    secret: tesaevdv123edsftesaevdv123edsftesaevdv123
+    expiration: 1000 * 60 * 5 # 5 minutes
+  refresh-token:
+    secret: tesaevdv123edsftesaevdv123edsftesaevdv112
+    expiration: 1000 * 60 * 60 * 3 # 3 hours

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,8 +3,8 @@ spring:
     name: makao-shop
 
   profiles:
-    include: local-db
-    active: prod-db
+    include: local-db, local-secret
+    active: prod-db, prod-secret
 
   jpa:
     show-sql: true

--- a/src/test/java/kr/co/shop/makao/component/TestJwtAlgorithmProviderImpl.java
+++ b/src/test/java/kr/co/shop/makao/component/TestJwtAlgorithmProviderImpl.java
@@ -1,0 +1,10 @@
+package kr.co.shop.makao.component;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+
+public class TestJwtAlgorithmProviderImpl implements JwtAlgorithmProvider {
+    @Override
+    public SignatureAlgorithm provide() {
+        return SignatureAlgorithm.HS256;
+    }
+}

--- a/src/test/java/kr/co/shop/makao/config/AuthConfig.java
+++ b/src/test/java/kr/co/shop/makao/config/AuthConfig.java
@@ -1,0 +1,16 @@
+package kr.co.shop.makao.config;
+
+import kr.co.shop.makao.component.JwtAlgorithmProvider;
+import kr.co.shop.makao.component.TestJwtAlgorithmProviderImpl;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@TestConfiguration
+public class AuthConfig {
+    @Primary
+    @Bean
+    public JwtAlgorithmProvider jwtAlgorithmProvider() {
+        return new TestJwtAlgorithmProviderImpl();
+    }
+}

--- a/src/test/java/kr/co/shop/makao/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/shop/makao/controller/AuthControllerTest.java
@@ -1,26 +1,49 @@
 package kr.co.shop.makao.controller;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import io.restassured.http.ContentType;
+import kr.co.shop.makao.component.JwtAlgorithmProvider;
+import kr.co.shop.makao.config.AuthProperties;
 import kr.co.shop.makao.config.PostgreInitializer;
 import kr.co.shop.makao.dto.AuthDTO;
 import kr.co.shop.makao.enums.UserRole;
+import kr.co.shop.makao.util.RandomString;
+import kr.co.shop.makao.util.StringEncoder;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.util.Date;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.equalTo;
 
 @ContextConfiguration(initializers = PostgreInitializer.class)
 class AuthControllerTest extends IntegrationTest {
+    @Autowired
+    private JwtAlgorithmProvider jwtAlgorithmProvider;
+    @Autowired
+    private AuthProperties authProperties;
+
+    private void insertUser(String name, String email, String phoneNumber, String password, UserRole role) {
+        transactionTemplate.execute(status -> {
+            em.createQuery("INSERT INTO user (name, email, phoneNumber, password, role) VALUES (:name, :email, :phoneNumber, :password, :role)")
+                    .setParameter("name", name)
+                    .setParameter("email", email)
+                    .setParameter("phoneNumber", phoneNumber)
+                    .setParameter("password", StringEncoder.encode(password))
+                    .setParameter("role", role)
+                    .executeUpdate();
+            return null;
+        });
+    }
+
     private String createRandomEmail() {
-        return (new Random()).ints(10, 48, 122)
-                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
-                .mapToObj(c -> String.valueOf((char) c))
-                .collect(Collectors.joining()) + "@example.com";
+        return RandomString.generateEngDigit(30) + "@example.com";
     }
 
     private String createRandomPhoneNumber() {
@@ -116,6 +139,119 @@ class AuthControllerTest extends IntegrationTest {
                     .then()
                     .statusCode(400)
                     .body("message", equalTo("INVALID_PASSWORD"))
+                    .body("data", equalTo(null));
+        }
+    }
+
+    @Nested
+    class signIn {
+        @Test
+        void signIn_성공() {
+            var dto = createRequest(createRandomEmail(), createRandomPhoneNumber());
+
+            insertUser(dto.name(), dto.email(), dto.phoneNumber(), dto.password(), dto.role());
+
+            given().contentType(ContentType.JSON)
+                    .body(AuthDTO.SignInRequest.builder()
+                            .email(dto.email())
+                            .password(dto.password())
+                            .build())
+                    .when()
+                    .post("/auth/sign-in")
+                    .then()
+                    .statusCode(200)
+                    .body("message", equalTo("OK"))
+                    .body("data.accessToken", any(String.class))
+                    .body("data.refreshToken", any(String.class));
+        }
+
+        @Test
+        void signIn_실패_이메일_존재하지_않음() {
+            var dto = createRequest(createRandomEmail(), createRandomPhoneNumber());
+
+            given().contentType(ContentType.JSON)
+                    .body(AuthDTO.SignInRequest.builder()
+                            .email(dto.email())
+                            .password(dto.password())
+                            .build())
+                    .when()
+                    .post("/auth/sign-in")
+                    .then()
+                    .statusCode(400)
+                    .body("message", equalTo("USER_NOT_FOUND"))
+                    .body("data", equalTo(null));
+        }
+
+        @Test
+        void signIn_실패_비밀번호_불일치() {
+            var dto = createRequest(createRandomEmail(), createRandomPhoneNumber());
+
+            insertUser(dto.name(), dto.email(), dto.phoneNumber(), dto.password(), dto.role());
+
+            given().contentType(ContentType.JSON)
+                    .body(AuthDTO.SignInRequest.builder()
+                            .email(dto.email())
+                            .password("wrongpassword123!")
+                            .build())
+                    .when()
+                    .post("/auth/sign-in")
+                    .then()
+                    .statusCode(400)
+                    .body("message", equalTo("AUTHENTICATION_FAILED"))
+                    .body("data", equalTo(null));
+        }
+    }
+
+    @Nested
+    class reissue {
+        private String createToken(String secret, long expiration) {
+            return Jwts.builder()
+                    .setSubject(createRandomEmail())
+                    .signWith(Keys.hmacShaKeyFor(secret.getBytes()), jwtAlgorithmProvider.provide())
+                    .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                    .compact();
+        }
+
+        @Test
+        void reissue_성공() {
+            given().contentType(ContentType.JSON)
+                    .body(AuthDTO.TokenReissueRequest.builder()
+                            .refreshToken(createToken(authProperties.getRefreshTokenSecret(), 10000))
+                            .build())
+                    .when()
+                    .post("/auth/token/reissue")
+                    .then()
+                    .statusCode(200)
+                    .body("message", equalTo("OK"))
+                    .body("data.accessToken", any(String.class));
+        }
+
+
+        @Test
+        void reissue_만료_실패() {
+            given().contentType(ContentType.JSON)
+                    .body(AuthDTO.TokenReissueRequest.builder()
+                            .refreshToken(createToken(authProperties.getRefreshTokenSecret(), -1000))
+                            .build())
+                    .when()
+                    .post("/auth/token/reissue")
+                    .then()
+                    .statusCode(400)
+                    .body("message", equalTo("EXPIRED_REFRESH_TOKEN"))
+                    .body("data", equalTo(null));
+        }
+
+        @Test
+        void reissue_잘못된_토큰_실패() {
+            given().contentType(ContentType.JSON)
+                    .body(AuthDTO.TokenReissueRequest.builder()
+                            .refreshToken(createToken(RandomString.generateEngDigit(40), 10000))
+                            .build())
+                    .when()
+                    .post("/auth/token/reissue")
+                    .then()
+                    .statusCode(400)
+                    .body("message", equalTo("INVALID_REFRESH_TOKEN"))
                     .body("data", equalTo(null));
         }
     }

--- a/src/test/java/kr/co/shop/makao/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/shop/makao/service/AuthServiceTest.java
@@ -1,14 +1,21 @@
 package kr.co.shop.makao.service;
 
+import kr.co.shop.makao.component.AuthTokenManager;
 import kr.co.shop.makao.dto.AuthDTO;
+import kr.co.shop.makao.enums.TokenType;
 import kr.co.shop.makao.enums.UserRole;
+import kr.co.shop.makao.response.CommonExceptionImpl;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -16,6 +23,8 @@ class AuthServiceTest {
     private AuthService authService;
     @Mock
     private UserService userService;
+    @Mock
+    private AuthTokenManager authTokenManager;
 
     @Test
     void signUp_성공() {
@@ -30,5 +39,70 @@ class AuthServiceTest {
         doNothing().when(userService).save(dto);
 
         authService.signUp(dto);
+    }
+
+    @Nested
+    class SignIn {
+        AuthDTO.SignInRequest dto = AuthDTO.SignInRequest.builder()
+                .email("email")
+                .password("password")
+                .build();
+
+        @Test
+        void signIn_성공() {
+            when(userService.verifyUser(dto.email(), dto.password())).thenReturn(true);
+            when(authTokenManager.create(dto.email(), TokenType.ACCESS_TOKEN)).thenReturn("accessToken");
+            when(authTokenManager.create(dto.email(), TokenType.REFRESH_TOKEN)).thenReturn("refreshToken");
+
+            var res = AuthDTO.SignInResponse.builder()
+                    .accessToken("accessToken")
+                    .refreshToken("refreshToken")
+                    .build();
+
+            assertThat(authService.signIn(dto)).isEqualTo(res);
+        }
+
+        @Test
+        void signIn_검증_실패() {
+            when(userService.verifyUser(dto.email(), dto.password())).thenReturn(false);
+
+            var exception = assertThrows(CommonExceptionImpl.class, () -> authService.signIn(dto));
+            assertThat(exception.getMessage()).isEqualTo("AUTHENTICATION_FAILED");
+        }
+    }
+
+    @Nested
+    class reissue {
+        AuthDTO.TokenReissueRequest dto = AuthDTO.TokenReissueRequest.builder()
+                .refreshToken("refreshToken")
+                .build();
+
+        @Test
+        void reissue_성공() {
+            when(authTokenManager.getSubject(dto.refreshToken(), TokenType.REFRESH_TOKEN)).thenReturn("email");
+            when(authTokenManager.create("email", TokenType.ACCESS_TOKEN)).thenReturn("accessToken");
+
+            var res = AuthDTO.TokenReissueResponse.builder()
+                    .accessToken("accessToken")
+                    .build();
+
+            assertThat(authService.reissue(dto)).isEqualTo(res);
+        }
+
+        @Test
+        void reissue_만료된_토큰() {
+            when(authTokenManager.getSubject(dto.refreshToken(), TokenType.REFRESH_TOKEN)).thenThrow(new io.jsonwebtoken.ExpiredJwtException(null, null, "message"));
+
+            var exception = assertThrows(CommonExceptionImpl.class, () -> authService.reissue(dto));
+            assertThat(exception.getMessage()).isEqualTo("EXPIRED_REFRESH_TOKEN");
+        }
+
+        @Test
+        void reissue_잘못된_토큰() {
+            when(authTokenManager.getSubject(dto.refreshToken(), TokenType.REFRESH_TOKEN)).thenThrow(new io.jsonwebtoken.security.SignatureException("message"));
+
+            var exception = assertThrows(CommonExceptionImpl.class, () -> authService.reissue(dto));
+            assertThat(exception.getMessage()).isEqualTo("INVALID_REFRESH_TOKEN");
+        }
     }
 }

--- a/src/test/java/kr/co/shop/makao/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/shop/makao/service/AuthServiceTest.java
@@ -92,21 +92,5 @@ class AuthServiceTest {
 
             assertThat(authService.reissue(dto).accessToken()).isEqualTo("accessToken");
         }
-
-        @Test
-        void reissue_만료된_토큰() {
-            when(authTokenManager.getSubject(dto.refreshToken(), TokenType.REFRESH_TOKEN)).thenThrow(new io.jsonwebtoken.ExpiredJwtException(null, null, "message"));
-
-            var exception = assertThrows(CommonExceptionImpl.class, () -> authService.reissue(dto));
-            assertThat(exception.getMessage()).isEqualTo("EXPIRED_REFRESH_TOKEN");
-        }
-
-        @Test
-        void reissue_잘못된_토큰() {
-            when(authTokenManager.getSubject(dto.refreshToken(), TokenType.REFRESH_TOKEN)).thenThrow(new io.jsonwebtoken.security.SignatureException("message"));
-
-            var exception = assertThrows(CommonExceptionImpl.class, () -> authService.reissue(dto));
-            assertThat(exception.getMessage()).isEqualTo("INVALID_REFRESH_TOKEN");
-        }
     }
 }

--- a/src/test/java/kr/co/shop/makao/service/UserServiceTest.java
+++ b/src/test/java/kr/co/shop/makao/service/UserServiceTest.java
@@ -1,10 +1,12 @@
 package kr.co.shop.makao.service;
 
 import kr.co.shop.makao.dto.AuthDTO;
+import kr.co.shop.makao.entity.User;
 import kr.co.shop.makao.enums.UserRole;
 import kr.co.shop.makao.repository.ExistsEmailAndPhoneNumber;
 import kr.co.shop.makao.repository.UserRepository;
 import kr.co.shop.makao.response.CommonExceptionImpl;
+import kr.co.shop.makao.util.StringEncoder;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,8 +14,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,6 +67,39 @@ class UserServiceTest {
 
             var exception = assertThrows(CommonExceptionImpl.class, () -> userService.save(dto));
             assert exception.getMessage().equals("PHONE_NUMBER_DUPLICATED");
+        }
+    }
+
+    @Nested
+    class validateUser {
+        @Test
+        void existsByEmail_성공_인증_성공() {
+            when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(User.builder().password("password123!").build()));
+
+            try (var d = mockStatic(StringEncoder.class)) {
+                when(StringEncoder.match(anyString(), anyString())).thenReturn(true);
+
+                assertThat(userService.verifyUser("email", "password123!")).isTrue();
+            }
+        }
+
+        @Test
+        void existsByEmail_성공_인증_실패() {
+            when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(User.builder().password("password123!").build()));
+
+            try (var d = mockStatic(StringEncoder.class)) {
+                when(StringEncoder.match(anyString(), anyString())).thenReturn(false);
+
+                assertThat(userService.verifyUser("email", "password123!")).isFalse();
+            }
+        }
+
+        @Test
+        void existsByEmail_이메일_없음_실패() {
+            when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+
+            var exception = assertThrows(CommonExceptionImpl.class, () -> userService.verifyUser("email", "password123!"));
+            assert exception.getMessage().equals("USER_NOT_FOUND");
         }
     }
 }

--- a/src/test/java/kr/co/shop/makao/service/UserServiceTest.java
+++ b/src/test/java/kr/co/shop/makao/service/UserServiceTest.java
@@ -6,7 +6,6 @@ import kr.co.shop.makao.enums.UserRole;
 import kr.co.shop.makao.repository.ExistsEmailAndPhoneNumber;
 import kr.co.shop.makao.repository.UserRepository;
 import kr.co.shop.makao.response.CommonExceptionImpl;
-import kr.co.shop.makao.util.StringEncoder;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,7 +18,6 @@ import java.util.Optional;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,34 +69,20 @@ class UserServiceTest {
     }
 
     @Nested
-    class validateUser {
+    class findByEmail {
         @Test
-        void existsByEmail_성공_인증_성공() {
+        void findByEmail_성공() {
             when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(User.builder().password("password123!").build()));
 
-            try (var d = mockStatic(StringEncoder.class)) {
-                when(StringEncoder.match(anyString(), anyString())).thenReturn(true);
-
-                assertThat(userService.verifyUser("email", "password123!")).isTrue();
-            }
+            var user = userService.findByEmail("email");
+            assertThat(user.getPassword()).isEqualTo("password123!");
         }
 
         @Test
-        void existsByEmail_성공_인증_실패() {
-            when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(User.builder().password("password123!").build()));
-
-            try (var d = mockStatic(StringEncoder.class)) {
-                when(StringEncoder.match(anyString(), anyString())).thenReturn(false);
-
-                assertThat(userService.verifyUser("email", "password123!")).isFalse();
-            }
-        }
-
-        @Test
-        void existsByEmail_이메일_없음_실패() {
+        void findByEmail_이메일_없음_실패() {
             when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());
 
-            var exception = assertThrows(CommonExceptionImpl.class, () -> userService.verifyUser("email", "password123!"));
+            var exception = assertThrows(CommonExceptionImpl.class, () -> userService.findByEmail("email"));
             assert exception.getMessage().equals("USER_NOT_FOUND");
         }
     }

--- a/src/test/resources/application-test-secret.yml
+++ b/src/test/resources/application-test-secret.yml
@@ -1,0 +1,7 @@
+auth:
+  access-token:
+    secret: tesaevdv123edsftesaevdv123edsftesaevdv123
+    expiration: 1000 * 60 * 5 # 5 minutes
+  refresh-token:
+    secret: tesaevdv123edsftesaevdv123edsftesaevdv112
+    expiration: 1000 * 60 * 60 * 3 # 3 hours

--- a/src/test/resources/application-test-secret.yml
+++ b/src/test/resources/application-test-secret.yml
@@ -5,3 +5,4 @@ auth:
   refresh-token:
     secret: tesaevdv123edsftesaevdv123edsftesaevdv112
     expiration: 1000 * 60 * 60 * 3 # 3 hours
+  is-dev-mode: false


### PR DESCRIPTION
## 🗂 Related Issues

Fixes #1 

## 📋 Description

로그인 및 토큰 재발급 구현했습니다.
추가로 헤더 검증 필터 추가했습니다.
개발 환경에서는 Authorization에 이메일을 넣으면 됩니다.

## 🛠 Changes

<!-- PR에서 작업한 변경사항을 간략히 나열하세요 -->

- [Chore : AuthTokenManager 구현(token 생성)](https://github.com/Makao-team/shop/pull/6/commits/2143e913a7d2e0f7bf3246a5cbdab5d8022a832a)
- [Feat : AuthController signIn 구현](https://github.com/Makao-team/shop/pull/6/commits/cc611678e5f2290acff4c090879d939f989ff21d)
- [Feat : AuthController reissue 구현](https://github.com/Makao-team/shop/pull/6/commits/e6fc345b16c328fdbe11d299646a3f03462ef347)
- [Chore : TokenAuthFilter 구현(헤더 토큰 검증)](https://github.com/Makao-team/shop/pull/6/commits/4c4c6e4a0495370d1f6701e20d78c87a0725c566)

## ✅ Checklist

- [x] 코드는 컴파일됩니다.
- [x] 테스트가 추가되었거나 기존 테스트가 통과합니다.
- [x] 코딩 컨벤션을 준수했습니다.

