### PR TITLE
Refac/#8 테스트 코드 개선

### DIFF
--- a/src/test/java/kr/co/shop/makao/config/TestAuthConfig.java
+++ b/src/test/java/kr/co/shop/makao/config/TestAuthConfig.java
@@ -13,4 +13,17 @@ public class TestAuthConfig {
     public JwtAlgorithmProvider testJwtAlgorithmProvider() {
         return new TestJwtAlgorithmProviderImpl();
     }
+
+    @Primary
+    @Bean
+    public AuthProperties testAuthProperties(JwtAlgorithmProvider jwtAlgorithmProvider) {
+        return new AuthProperties(
+                "test-access-token-secret",
+                "60*1000",
+                "test-refresh-token-secret",
+                "60*60*1000",
+                "false",
+                jwtAlgorithmProvider
+        );
+    }
 }

--- a/src/test/java/kr/co/shop/makao/controller/BaseIntegrationTest.java
+++ b/src/test/java/kr/co/shop/makao/controller/BaseIntegrationTest.java
@@ -1,0 +1,50 @@
+package kr.co.shop.makao.controller;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import kr.co.shop.makao.entity.User;
+import kr.co.shop.makao.enums.UserRole;
+import kr.co.shop.makao.util.RandomString;
+import kr.co.shop.makao.util.StringEncoder;
+
+import java.util.Date;
+import java.util.Random;
+
+public abstract class BaseIntegrationTest extends IntegrationTest {
+    protected void insertUser(String name, String email, String phoneNumber, String password, UserRole role) {
+        transactionTemplate.execute(status -> {
+            em.createQuery("INSERT INTO user (name, email, phoneNumber, password, role) VALUES (:name, :email, :phoneNumber, :password, :role)")
+                    .setParameter("name", name)
+                    .setParameter("email", email)
+                    .setParameter("phoneNumber", phoneNumber)
+                    .setParameter("password", StringEncoder.encode(password))
+                    .setParameter("role", role)
+                    .executeUpdate();
+            return null;
+        });
+    }
+
+    protected User findUserByEmail(String email) {
+        return transactionTemplate.execute(
+                status -> em.createQuery("SELECT u FROM user u WHERE u.email = :email", User.class)
+                        .setParameter("email", email)
+                        .getSingleResult()
+        );
+    }
+
+    protected String createRandomEmail() {
+        return RandomString.generateEngDigit(30) + "@example.com";
+    }
+
+    protected String createRandomPhoneNumber() {
+        return "010-" + new Random().nextInt(10000) + "-" + new Random().nextInt(10000);
+    }
+
+    protected String createToken(Algorithm algorithm, long expiration, UserRole role, String email) {
+        return JWT.create()
+                .withSubject(email)
+                .withClaim("role", role.getValue())
+                .withExpiresAt(new Date(System.currentTimeMillis() + expiration))
+                .sign(algorithm);
+    }
+}

--- a/src/test/resources/application-test-secret.yml
+++ b/src/test/resources/application-test-secret.yml
@@ -1,8 +1,0 @@
-auth:
-  access-token:
-    secret: tesaevdv123edsftesaevdv123edsftesaevdv123
-    expiration: 1000 * 60 * 5 # 5 minutes
-  refresh-token:
-    secret: tesaevdv123edsftesaevdv123edsftesaevdv112
-    expiration: 1000 * 60 * 60 * 3 # 3 hours
-  is-dev-mode: false


### PR DESCRIPTION
## 🗂 Related Issues

Working #8 

## 📋 Description

BaseIntegrationTest 추가(중복으로 사용되는 User insert 쿼리 등 공통화)
testAuthProperties 테스트용 빈을 추가함으로써 설정 파일 제거

## 🛠 Changes

- [Chore : BaseIntegrationTest 추가(중복 메서드 공통화)](https://github.com/Makao-team/shop/pull/12/commits/0abdf30a5aa1fc672c2a9ac25ebfbf1d6a73b2d2)
- [Chore : 테스트용 testAuthProperties 빈 추가](https://github.com/Makao-team/shop/pull/12/commits/b1ea7b87f1be56862340beedb550fd9668f86ecd)

## ✅ Checklist

- [x] 코드는 컴파일됩니다.
- [x] 테스트가 추가되었거나 기존 테스트가 통과합니다.
- [x] 코딩 컨벤션을 준수했습니다.

